### PR TITLE
chore(grunt-latex): use original repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "grunt": "~0.4.5",
     "grunt-aws-s3": "^0.12.1",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-latex": "git://github.com/javiercejudo/grunt-latex.git#shell-escape"
+    "grunt-latex": "~1.0.0"
   }
 }


### PR DESCRIPTION
The original repo includes the shellEscape option since v1.0.0
